### PR TITLE
Refactor Shuffle function

### DIFF
--- a/Tetris/Presenter.cs
+++ b/Tetris/Presenter.cs
@@ -50,7 +50,7 @@ namespace Tetris.Presenter
                 else
                 {
                     indexOfNextBlock = 0;
-                    Shuffle();
+                    blocks = Shuffle(blocks);
                 }
             }
         }
@@ -75,7 +75,7 @@ namespace Tetris.Presenter
             RandomBlock = rand.Next(0, 7);
 
             blocks = Enumerable.Range(0, 7).ToArray();
-            Shuffle();
+            blocks = Shuffle(blocks);
             IndexOfNextBlock = RandomBlock;
 
             block = new Block(blocks[RandomBlock], StartPoint, board);
@@ -123,7 +123,7 @@ namespace Tetris.Presenter
                     View.TheBestResult = (int)Settings.Default["TheBestResult"];
 
                     blocks = Enumerable.Range(0, 7).ToArray();
-                    Shuffle();
+                    blocks = Shuffle(blocks);
                     //IndexOfNextBlock = RandomBlock;
 
                     block = new Block(blocks[RandomBlock], StartPoint, board);
@@ -251,18 +251,19 @@ namespace Tetris.Presenter
 
             View.Board = DraftForNextBlock;
         }
-        public static void Shuffle()
+
+        public static int[] Shuffle(int[] blocks)
         {
-            Random rng = new Random();
-            int n = blocks.Length;
-            while (n > 1)
-            {
-                n--;
-                int k = rng.Next(n + 1);
-                int value = blocks[k];
-                blocks[k] = blocks[n];
-                blocks[n] = value;
-            }
+            Random rnd = new Random();
+			for (int i = blocks.Length - 1; i > 1; i--) 
+			{
+				int newIndex = rnd.Next(i + 1);
+                int buffer = blocks[i];
+                blocks[i] = blocks[newIndex];
+                blocks[newIndex] = buffer;
+			}
+
+            return blocks;
         }
     }
 }

--- a/Tetris/Tetris.csproj
+++ b/Tetris/Tetris.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Tetris</RootNamespace>
     <AssemblyName>Tetris</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/Tetris/TetrisTests/PresenterTests.cs
+++ b/Tetris/TetrisTests/PresenterTests.cs
@@ -1,0 +1,48 @@
+﻿//
+// PresenterTests.cs
+//
+// Author:
+//       g07cha <azizovkostya97@gmail.com>
+//
+// Copyright (c) 2016 g07cha
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using NUnit.Framework;
+using System;
+using System.Windows.Forms;
+using Tetris.Presenter;
+
+namespace TetrisTests
+{
+    [TestFixture ()]
+    public class PresenterTests
+    {
+        [Test ()]
+        public void ShuffleTest ()
+        {
+            int[] blocks = new int[]{ 1, 2, 3, 4 };
+            
+            int[] result = presenter.Shuffle(blocks);
+
+            Assert.IsInstanceOf<int[]>(result);
+            Assert.AreEqual(blocks.GetLength(0), result.GetLength(0));
+        }
+    }
+}
+

--- a/Tetris/TetrisTests/Test.cs
+++ b/Tetris/TetrisTests/Test.cs
@@ -1,0 +1,15 @@
+﻿using NUnit.Framework;
+using System;
+
+namespace TetrisTests
+{
+	[TestFixture ()]
+	public class Test
+	{
+		[Test ()]
+		public void TestCase ()
+		{
+		}
+	}
+}
+

--- a/Tetris/TetrisTests/TetrisTests.csproj
+++ b/Tetris/TetrisTests/TetrisTests.csproj
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{5303A005-B0F1-40A1-8CAA-F4DEADB21B02}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>TetrisTests</RootNamespace>
+    <AssemblyName>TetrisTests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="nunit.framework">
+      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Windows.Forms" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Test.cs" />
+    <Compile Include="PresenterTests.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Tetris.csproj">
+      <Project>{44F6CDDA-2ADF-4865-94D8-594763BE6FBD}</Project>
+      <Name>Tetris</Name>
+    </ProjectReference>
+  </ItemGroup>
+</Project>

--- a/Tetris/TetrisTests/packages.config
+++ b/Tetris/TetrisTests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
Using for loop which is more suitable for this situation and working with blocks as with argument because it makes function more independent.
- Cover `Shuffle` function with unit tests
- Lower .NET version to 4.5(for compatibility with Mono)
